### PR TITLE
hotfix workflow crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 2021-09-27
+
+Fixes crash when workflow is enabled but no hostnames are configured for it.
+
 ## 1.0.1 2021-08-25
 
 The headers `Referrer-Policy`, `X-Content-Type-Options` and `Permissions-Policy` were inadvertently left off a list that allows them to be configured. The default values for the first two are now as was always intended. The third is not enabled by default but can now optionally be configured.

--- a/index.js
+++ b/index.js
@@ -119,8 +119,8 @@ module.exports = {
       if (workflow) {
         hosts = [
           ...hosts,
-          Object.values(workflow.options.hostnames),
-          Object.keys(workflow.options.defaultLocalesByHostname)
+          Object.values(workflow.options.hostnames || {}),
+          Object.keys(workflow.options.defaultLocalesByHostname || {})
         ];
       }
       const mediaUrl = self.apos.attachments.uploadfs.getUrl();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-security-headers",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Send security headers such as Strict-Transport-Security in a way compatible with the needs of Apostrophe 2.x",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This a straightforward bug preventing deployment on our own website. Because an enterprise client with localization was the main customer when this module was first created, I missed the case where the site has workflow but no hostnames for locales.